### PR TITLE
Added force delete option to PurgeCommand for soft delete compatibility

### DIFF
--- a/config/expirable.php
+++ b/config/expirable.php
@@ -15,6 +15,16 @@ return [
 
     'attribute_name' => 'expires_at',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Mode
+    |--------------------------------------------------------------------------
+    |
+    | Whether the expirable:purge command deletion defaults to hard or soft.
+    | Defaults to hard for backward compatibility.
+    |
+    */
+    'mode' => 'hard',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -16,7 +16,8 @@ class PurgeCommand extends Command
      */
     protected $signature = 'expirable:purge
                             {model?* : Optional list of models to purge. If not provided, will take the models in the purge array of the configuration file.}
-                            {--since= : Time since expiration.}';
+                            {--since= : Time since expiration.}
+                            {--force : Force delete models.}';
 
     /**
      * The console command description.
@@ -41,6 +42,7 @@ class PurgeCommand extends Command
         if (count($models)) {
 
             $expiredSince = $this->option('since');
+            $force = $this->option('force');
 
             $this->line('');
             $this->comment('Deleting expired records...');
@@ -58,7 +60,7 @@ class PurgeCommand extends Command
                         $query = call_user_func($purgeable . '::expiredSince', $expiredSince);
                     }
 
-                    $total = $query->forceDelete();
+                    $total = $force ? $query->forceDelete() : $query->delete();
 
                     if ($total > 0) {
                         $this->info($total . ' ' . Str::plural('record', $total) . ' deleted.');

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -17,7 +17,7 @@ class PurgeCommand extends Command
     protected $signature = 'expirable:purge
                             {model?* : Optional list of models to purge. If not provided, will take the models in the purge array of the configuration file.}
                             {--since= : Time since expiration.}
-                            {--force : Force delete models.}';
+                            {--mode= : Whether the deletion mode is "soft" (hard otherwise). If not provided, will take the mode value of the configuration file or default to "hard".}';
 
     /**
      * The console command description.
@@ -42,7 +42,7 @@ class PurgeCommand extends Command
         if (count($models)) {
 
             $expiredSince = $this->option('since');
-            $force = $this->option('force');
+            $mode = $this->option('mode') ?: Config::get('expirable.mode', 'hard');
 
             $this->line('');
             $this->comment('Deleting expired records...');
@@ -60,7 +60,7 @@ class PurgeCommand extends Command
                         $query = call_user_func($purgeable . '::expiredSince', $expiredSince);
                     }
 
-                    $total = $force ? $query->forceDelete() : $query->delete();
+                    $total = Str::lower($mode) == 'soft' ? $query->delete() : $query->forceDelete();
 
                     if ($total > 0) {
                         $this->info($total . ' ' . Str::plural('record', $total) . ' deleted.');


### PR DESCRIPTION
Hi I ran into an issue when I tried the purge command, because the project I'm working on uses soft deletes. This PR adds a `--force` option to call `forceDelete()` internally, falling back to the regular `delete()` otherwise:

```
php artisan expirable:purge --force
```

Feel free to modify this however you want, it's just for your convenience! And many thanks for making this package.

***

Also just FYI, hard deleting rows will fail most of the time in the real world on tables with foreign keys that don't have the cascade-deletes option set. So ideally this would delete the child tables first. So for example if `users.phone_id` pointed to `phones.id`, then the users row should be deleted before the phones row. Otherwise users.phone_id has nothing to point to. This is beyond the scope of your command though, and should probably be provided by a third party framework or built into Laravel. A workaround is to pass the models in child-to-parent order:

```
php artisan expirable:purge --force "App\User" "App\Phone"
```

Or list them that way in the `purge` key in `config/expirable.php`:

```
    'purge' => [
        App\User::class,
        App\Phone::class,
    ],
```